### PR TITLE
Arc-601 Do not QueryHistory if there is no update event

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 cabbie.exe
+
+.idea/


### PR DESCRIPTION
https://learn.microsoft.com/en-us/windows/win32/api/wuapi/nf-wuapi-iupdatesearcher-gettotalhistorycount
https://learn.microsoft.com/en-us/windows/win32/api/wuapi/nf-wuapi-iupdatesearcher-queryhistory

We now return the total count of update event, if it's 0 we return 0 and it no longer issues an error

The invoke with 0 as an argument was most likely causing the error:
https://learn.microsoft.com/en-us/windows/win32/api/oaidl/nf-oaidl-idispatch-invoke
DISP_E_EXCEPTION

We can make the system call directly with powershell and see that there is nothing to retrieve

```
PS C:\Program Files\NozomiNetworks\Arc> $WuaHistory = (New-Object -ComObject 'Microsoft.Update.Session').QueryHistory("",0,100)
PS C:\Program Files\NozomiNetworks\Arc> echo $WuaHistory

_NewEnum           Count
--------           -----
System.__ComObject     0
```

Fetching with a count of 0 fails

```
PS C:\Program Files\NozomiNetworks\Arc> echo $TotalUpdatesCount
0
PS C:\Program Files\NozomiNetworks\Arc> $TotalUpdates = $Searcher.QueryHistory(0, $TotalUpdatesCount)
Exception from HRESULT: 0x80240007
At line:1 char:1
+ $TotalUpdates = $Searcher.QueryHistory(0, $TotalUpdatesCount)
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : OperationStopped: (:) [], COMException
    + FullyQualifiedErrorId : System.Runtime.InteropServices.COMException
```